### PR TITLE
Switch to https for call to API

### DIFF
--- a/js/centralized-rbc-with-labor-simulation.js
+++ b/js/centralized-rbc-with-labor-simulation.js
@@ -639,7 +639,7 @@ $(document).ready(function () {
         }
 
         $.ajax(
-            'http://letsgoexploring.techb.us/api/v1/centralized-rbc-with-labor-simulation/',
+            'https://letsgoexploring.techb.us/api/v1/centralized-rbc-with-labor-simulation/',
             {
                 dataType: 'json',
                 data: reqData


### PR DESCRIPTION
@letsgoexploring the issue seems to have been that your site is now loading via HTTPS, which is great, but that the backend was being called via HTTP which was causing a "mixed content" error, which is a browser security measure to make sure that secure pages stay secure and don't load any insecure resources. I've also upgraded connections to the API to HTTPS so this should now work after this is merged.